### PR TITLE
Integrate deduplication for single-shot and multi-hop questions

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -780,18 +780,34 @@ def main():
         all_questions.extend([{**item, 'question_type': question_type} for item in dataset])
     combined_dataset = Dataset.from_list(all_questions)
     
+    # Push original single-shot questions to HuggingFace
+    original_output = f"{single_shot_question_settings['output_dataset']}-original"
+    logger.info(f"Pushing original single-shot questions to {original_output}")
+    push_single_shot_questions_to_huggingface(combined_dataset, original_output)
+    
     # Deduplicate single-shot questions
     deduplicated_dataset = deduplicate_questions(combined_dataset, args, 'single-shot')
     
     # Push deduplicated single-shot questions to HuggingFace
-    push_single_shot_questions_to_huggingface(deduplicated_dataset, single_shot_question_settings['output_dataset'])
+    dedup_output = f"{single_shot_question_settings['output_dataset']}-deduplicated"
+    logger.info(f"Pushing deduplicated single-shot questions to {dedup_output}")
+    push_single_shot_questions_to_huggingface(deduplicated_dataset, dedup_output)
     
-    # Generate and deduplicate multi-hop questions
+    # Generate multi-hop questions from deduplicated single-shot questions
     multihop_dataset = generate_multihop_questions(deduplicated_dataset, engine, args.max_concurrent)
+    
+    # Push original multi-hop questions to HuggingFace
+    original_multihop_output = f"{single_shot_question_settings['output_dataset']}-multihop-original"
+    logger.info(f"Pushing original multi-hop questions to {original_multihop_output}")
+    push_multihop_questions_to_huggingface(multihop_dataset, original_multihop_output)
+    
+    # Deduplicate multi-hop questions
     deduplicated_multihop = deduplicate_questions(multihop_dataset, args, 'multi-hop')
     
     # Push deduplicated multi-hop questions to HuggingFace
-    push_multihop_questions_to_huggingface(deduplicated_multihop, f"{single_shot_question_settings['output_dataset']}-multihop")
+    dedup_multihop_output = f"{single_shot_question_settings['output_dataset']}-multihop-deduplicated"
+    logger.info(f"Pushing deduplicated multi-hop questions to {dedup_multihop_output}")
+    push_multihop_questions_to_huggingface(deduplicated_multihop, dedup_multihop_output)
 
     logger.info("Single-shot questions generated successfully")
     


### PR DESCRIPTION
This PR integrates the deduplication functionality for both single-shot and multi-hop questions.

Changes:
- Add deduplication settings to argument parser
- Create deduplicate_questions helper function
- Modify main function to deduplicate both single-shot and multi-hop questions
- Combine questions by type before deduplication
- Save deduplication plots and statistics for each dataset type

The changes ensure that:
- Questions are deduplicated across all question types
- Multi-hop questions are generated from deduplicated single-shot questions
- Deduplication plots and statistics are saved separately for each dataset type
- The process is configurable through command-line arguments or environment variables